### PR TITLE
Change script file variable to "static"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distlock",
-  "version": "1.1.99-edge-lts.2",
+  "version": "1.1.99-edge-lts.3",
   "description": "distributed lock implementation using redis, supporting promise and typescript",
   "main": "dist/distlock.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "source-map-support": "^0.4.2"
   },
   "devDependencies": {
+    "typescript": "<2.3",
     "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-istanbul": "^1.1.1",


### PR DESCRIPTION
짧은 시간동안 많은 distlock이 생성되고 실행되는 경우, lua 파일을 읽지 못하는 문제 발생
후에 unlock / lock이 정상적으로 처리되지 않아서 exceeds retry count 에러가 발생해서 distlock을 사용하는 로직이 망함
lua 파일의 내용은 변화되지 않으니, DistLock.script를 static으로 바꾸고 계속 재사용할 수 있도록 함